### PR TITLE
fix: fix bug: Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback

### DIFF
--- a/Casdoor.php
+++ b/Casdoor.php
@@ -73,7 +73,7 @@ class Casdoor
      *
      * @return void
      */
-    public function custom_login()
+    public static function custom_login()
     {
         global $pagenow;
         $activated = absint(casdoor_get_option('active'));


### PR DESCRIPTION
Fix: https://github.com/casdoor/wordpress-casdoor-plugin/issues/14