### PR TITLE
fix “Undefined array key 'action'” warning

### DIFF
--- a/Casdoor.php
+++ b/Casdoor.php
@@ -73,13 +73,17 @@ class Casdoor
      *
      * @return void
      */
-    public static function custom_login()
-    {
+    public static function custom_login() {
         global $pagenow;
-        $activated = absint(casdoor_get_option('active'));
-        if ('wp-login.php' == $pagenow && $_GET['action'] != 'logout' && $activated) {
+        $activated = absint( casdoor_get_option( 'active' ) );
+        $action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING ) ?? '';
+        if (
+            'wp-login.php' === $pagenow
+            && 'logout'     !== $action
+            && $activated
+        ) {
             $url = get_casdoor_login_url();
-            wp_redirect($url);
+            wp_redirect( $url );
             exit();
         }
     }


### PR DESCRIPTION
In PHP 8.0+, direct access to a non-existent array key throws an Undefined array key warning. The WordPress plugin's Casdoor.php uses $_GET['action'] without prior judgment, resulting in a warning when visiting a page where this parameter does not exist.
`NOTICE: PHP message: PHP Warning: Undefined array key "action"`
For this I fixed this bug